### PR TITLE
Fix signal selection persistence across filter operations

### DIFF
--- a/can_analyzer/main.py
+++ b/can_analyzer/main.py
@@ -4,6 +4,10 @@ CAN Analyzer - Main Entry Point
 """
 
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
 from PyQt6.QtWidgets import QApplication
 from ui.main_window import MainWindow
 

--- a/can_analyzer/ui/signal_selection_dialog.py
+++ b/can_analyzer/ui/signal_selection_dialog.py
@@ -8,7 +8,7 @@ from PyQt6.QtWidgets import (
     QAbstractItemView, QLineEdit
 )
 from PyQt6.QtCore import Qt
-from typing import List, Dict, Set
+from typing import List, Dict, Set, Tuple
 from utils.dbc_manager import DBCManager
 
 
@@ -21,6 +21,8 @@ class SignalSelectionDialog(QDialog):
         self.can_ids = can_ids
         self.selected_signals: List[Dict] = []
         self._all_items: List[tuple] = []  # (text, data_dict)
+        self._selected_keys: Set[Tuple[int, str]] = set()
+        self._syncing: bool = False
 
         self.setWindowTitle("选择信号")
         self.setMinimumSize(600, 400)
@@ -131,45 +133,70 @@ class SignalSelectionDialog(QDialog):
         """Filter signal list based on search text"""
         query = text.strip().lower()
 
-        self.signal_list.clear()
+        self._syncing = True
+        try:
+            self.signal_list.clear()
 
-        for item_text, data in self._all_items:
-            if not query:
-                match = True
-            else:
-                can_id = data['can_id']
-                # Match against signal/message name (fuzzy)
-                name_text = f"{data['message_name']}.{data['signal_name']}".lower()
-                name_match = self._fuzzy_match(query, name_text)
-                # Match against message ID (hex and decimal substring)
-                id_hex = f"0x{can_id:03x}"
-                id_dec = str(can_id)
-                id_match = query in id_hex or query in id_dec
-                match = name_match or id_match
+            for item_text, data in self._all_items:
+                if not query:
+                    match = True
+                else:
+                    can_id = data['can_id']
+                    # Match against signal/message name (fuzzy)
+                    name_text = f"{data['message_name']}.{data['signal_name']}".lower()
+                    name_match = self._fuzzy_match(query, name_text)
+                    # Match against message ID (hex and decimal substring)
+                    id_hex = f"0x{can_id:03x}"
+                    id_dec = str(can_id)
+                    id_match = query in id_hex or query in id_dec
+                    match = name_match or id_match
 
-            if match:
-                item = QListWidgetItem(item_text)
-                item.setData(Qt.ItemDataRole.UserRole, data)
-                self.signal_list.addItem(item)
+                if match:
+                    item = QListWidgetItem(item_text)
+                    item.setData(Qt.ItemDataRole.UserRole, data)
+                    self.signal_list.addItem(item)
+                    if (data['can_id'], data['signal_name']) in self._selected_keys:
+                        item.setSelected(True)
+        finally:
+            self._syncing = False
 
         self.update_stats()
 
     def select_all(self):
         """Select all signals"""
         self.signal_list.selectAll()
+        for i in range(self.signal_list.count()):
+            data = self.signal_list.item(i).data(Qt.ItemDataRole.UserRole)
+            if data:
+                self._selected_keys.add((data['can_id'], data['signal_name']))
+        self.update_stats()
 
     def clear_selection(self):
         """Clear all selections"""
         self.signal_list.clearSelection()
+        self._selected_keys.clear()
+        self.update_stats()
 
     def on_selection_changed(self):
         """Handle selection change"""
+        if self._syncing:
+            return
+        for i in range(self.signal_list.count()):
+            item = self.signal_list.item(i)
+            data = item.data(Qt.ItemDataRole.UserRole)
+            if not data:
+                continue
+            key = (data['can_id'], data['signal_name'])
+            if item.isSelected():
+                self._selected_keys.add(key)
+            else:
+                self._selected_keys.discard(key)
         self.update_stats()
 
     def update_stats(self):
         """Update statistics label"""
         total = self.signal_list.count()
-        selected = len(self.signal_list.selectedItems())
+        selected = len(self._selected_keys)
 
         self.stats_label.setText(f"总共 {total} 个信号，已选择 {selected} 个")
 
@@ -184,10 +211,9 @@ class SignalSelectionDialog(QDialog):
             List of dicts with signal info
         """
         selected = []
-        for item in self.signal_list.selectedItems():
-            signal_info = item.data(Qt.ItemDataRole.UserRole)
-            if signal_info:
-                selected.append(signal_info)
+        for _text, data in self._all_items:
+            if (data['can_id'], data['signal_name']) in self._selected_keys:
+                selected.append(data)
         return selected
 
     def accept(self):


### PR DESCRIPTION
## Summary
This PR fixes a bug where signal selections were lost when applying filters in the signal selection dialog. The solution introduces persistent tracking of selected signals independent of the current list view state.

## Key Changes
- **Added selection state tracking**: Introduced `_selected_keys` (Set of tuples) to maintain selected signals across filter operations, and `_syncing` flag to prevent redundant updates during filter application
- **Updated `apply_filter()` method**: Wrapped filter logic in try-finally block to manage sync state, and restore selection state for items matching the filter
- **Enhanced `select_all()` and `clear_selection()` methods**: Now update `_selected_keys` to keep selection state synchronized
- **Refactored `on_selection_changed()` method**: Added sync guard and logic to update `_selected_keys` based on current item selection state
- **Modified `update_stats()` method**: Changed to use `_selected_keys` length instead of `selectedItems()` count for accurate statistics
- **Updated `get_selected_signals()` method**: Changed to iterate through all items and check against `_selected_keys` instead of relying on `selectedItems()`, ensuring correct results regardless of current filter state
- **Fixed import path in main.py**: Added proper sys.path handling to resolve module imports correctly

## Implementation Details
The key insight is that `QListWidget.selectedItems()` only returns items currently visible in the list. By maintaining a separate set of selected signal keys `(can_id, signal_name)`, the dialog can preserve user selections across filter operations and accurately report selected signals even when they're not visible due to filtering.

https://claude.ai/code/session_01MYkhRnY9eBY943mZt1c12m