### PR TITLE
Add absolute time formatting support for CAN messages

### DIFF
--- a/can_analyzer/parsers/asc_parser.py
+++ b/can_analyzer/parsers/asc_parser.py
@@ -79,6 +79,7 @@ class ASCParser:
     def __init__(self):
         self.messages: List[CANMessage] = []
         self.start_date: Optional[str] = None
+        self.start_datetime: Optional[datetime] = None
         self.base_format: str = 'hex'
         self.timestamp_format: str = 'absolute'
 
@@ -131,6 +132,7 @@ class ASCParser:
         import can
 
         self.messages.clear()
+        self._read_file_header(file_path)
 
         try:
             with can.ASCReader(file_path) as reader:
@@ -217,11 +219,46 @@ class ASCParser:
 
         return self.messages
 
+    def _read_file_header(self, file_path: str):
+        """Read and parse only the header lines of an ASC file."""
+        try:
+            with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or line.startswith(';'):
+                        continue
+                    if line.startswith('date'):
+                        self._parse_date(line)
+                    elif line.startswith('base'):
+                        self._parse_base(line)
+                    elif line.startswith('timestamps'):
+                        self._parse_timestamps(line)
+                    elif line.startswith('Begin') or line.startswith('End'):
+                        break
+                    elif re.match(r'^\s*[\d.]+\s', line):
+                        break  # First message line, stop
+        except Exception:
+            pass  # Header parsing failure is non-fatal
+
     def _parse_date(self, line: str):
         """Parse date header line."""
         parts = line.split()
         if len(parts) >= 2:
             self.start_date = ' '.join(parts[1:])
+            self.start_datetime = self._parse_date_string(self.start_date)
+
+    def _parse_date_string(self, date_str: str) -> Optional[datetime]:
+        """Parse an ASC date string into a datetime object."""
+        formats = [
+            "%a %b %d %H:%M:%S.%f %Y",
+            "%a %b %d %H:%M:%S %Y",
+        ]
+        for fmt in formats:
+            try:
+                return datetime.strptime(date_str, fmt)
+            except ValueError:
+                continue
+        return None
 
     def _parse_base(self, line: str):
         """Parse base format header line."""

--- a/can_analyzer/ui/main_window.py
+++ b/can_analyzer/ui/main_window.py
@@ -273,6 +273,10 @@ class MainWindow(QMainWindow):
         # Store messages
         self.current_messages = messages
 
+        # Pass start datetime to formatter for absolute time conversion
+        start_datetime = stats.get('start_datetime') if stats else None
+        self.message_table.set_base_datetime(start_datetime)
+
         # Display messages in table
         self.message_table.set_messages(messages)
 

--- a/can_analyzer/ui/message_table.py
+++ b/can_analyzer/ui/message_table.py
@@ -113,8 +113,11 @@ class MessageTableWidget(QTableWidget):
     def set_timestamp_format(self, format_type: TimestampFormat):
         """Set timestamp display format"""
         self.timestamp_formatter.set_format(format_type)
-        # Refresh display
         self.refresh_display()
+
+    def set_base_datetime(self, base_datetime):
+        """Set the base datetime for absolute time conversion"""
+        self.timestamp_formatter.set_base_datetime(base_datetime)
 
     def set_messages(self, messages: List[CANMessage]):
         """
@@ -449,10 +452,16 @@ class MessageTableWidget(QTableWidget):
             (TimestampFormat.SECONDS, "秒"),
             (TimestampFormat.MILLISECONDS, "毫秒"),
             (TimestampFormat.MICROSECONDS, "微秒"),
+            (TimestampFormat.TIME_OF_DAY, "实际时间"),
         ]
 
         for fmt, name in formats:
             action = QAction(name, self)
+            if fmt == TimestampFormat.TIME_OF_DAY:
+                has_base = self.timestamp_formatter.base_datetime is not None
+                action.setEnabled(has_base)
+                if not has_base:
+                    action.setToolTip("需要文件包含日期信息才能显示实际时间")
             action.triggered.connect(lambda checked, f=fmt: self.set_timestamp_format(f))
             ts_menu.addAction(action)
 

--- a/can_analyzer/utils/file_import_worker.py
+++ b/can_analyzer/utils/file_import_worker.py
@@ -57,6 +57,8 @@ class FileImportWorker(QThread):
             stats = {}
             if parser:
                 stats = parser.get_statistics()
+                if hasattr(parser, 'start_datetime') and parser.start_datetime is not None:
+                    stats['start_datetime'] = parser.start_datetime
 
             # Stage 4: Complete (95-100%)
             self.progress_updated.emit("导入完成", 100)

--- a/can_analyzer/utils/timestamp_formatter.py
+++ b/can_analyzer/utils/timestamp_formatter.py
@@ -83,14 +83,14 @@ class TimestampFormatter:
         return f"{us:.0f}us"
 
     def _format_time_of_day(self, timestamp: float) -> str:
-        """Format as time of day (HH:MM:SS.mmm)"""
+        """Format as absolute time (HH:MM:SS.mmm, or YYYY-MM-DD HH:MM:SS.mmm for multi-day spans)"""
         if self.base_datetime is None:
-            # If no base datetime, just format as duration
             return self._format_duration(timestamp)
 
-        # Calculate absolute time
         absolute_time = self.base_datetime + timedelta(seconds=timestamp)
-        return absolute_time.strftime("%H:%M:%S.%f")[:-3]  # Remove last 3 digits
+        if absolute_time.date() != self.base_datetime.date():
+            return absolute_time.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        return absolute_time.strftime("%H:%M:%S.%f")[:-3]
 
     def _format_relative(self, timestamp: float) -> str:
         """Format as relative time from start"""


### PR DESCRIPTION
## Summary
This PR adds support for displaying CAN message timestamps as absolute time (wall-clock time) when the ASC file contains date information. Previously, timestamps could only be displayed as relative durations or in other formats.

## Key Changes

- **ASC Parser Enhancement**: Added `start_datetime` field to store parsed date from ASC file headers
  - New `_read_file_header()` method to extract header information before message parsing
  - New `_parse_date_string()` method to convert date strings to datetime objects
  - Integrated header parsing into the python-can parser workflow

- **Timestamp Formatter Improvement**: Enhanced `_format_time_of_day()` to handle multi-day spans
  - Falls back to duration format when no base datetime is available
  - Automatically includes date (YYYY-MM-DD) in output when timestamps span multiple days
  - Maintains HH:MM:SS.mmm format for same-day timestamps

- **UI Updates**: 
  - Added "实际时间" (Actual Time) option to timestamp format context menu
  - Menu option is disabled with tooltip when file lacks date information
  - New `set_base_datetime()` method in MessageTable to pass parsed datetime to formatter

- **Import Workflow**: Modified file import worker to extract and propagate `start_datetime` from parser statistics to the UI layer

## Implementation Details

- Header parsing is non-fatal; failures are silently ignored to maintain robustness
- Supports multiple date string formats (with/without microseconds)
- The TIME_OF_DAY format gracefully degrades to duration format when no base datetime is available
- Date information flows through: ASC Parser → Import Worker → Main Window → Message Table → Timestamp Formatter

https://claude.ai/code/session_015hMeEAkbobZZNWKXeZm9pP