### PR TITLE
fix: support 12-hour AM/PM date format in ASC file header

### DIFF
--- a/can_analyzer/parsers/asc_parser.py
+++ b/can_analyzer/parsers/asc_parser.py
@@ -252,6 +252,8 @@ class ASCParser:
         formats = [
             "%a %b %d %H:%M:%S.%f %Y",
             "%a %b %d %H:%M:%S %Y",
+            "%a %b %d %I:%M:%S %p %Y",    # 12-hour AM/PM (e.g. Thu May 14 11:18:07 AM 2026)
+            "%a %b %d %I:%M:%S.%f %p %Y",
         ]
         for fmt in formats:
             try:


### PR DESCRIPTION
ASC files from some tools use 12-hour time with AM/PM marker, e.g. "date Thu May 14 11:18:07 AM 2026". The previous parser only handled 24-hour formats, so start_datetime was never set, leaving the "实际时间" context-menu option permanently grayed out.

https://claude.ai/code/session_015hMeEAkbobZZNWKXeZm9pP